### PR TITLE
Corrected deprecated Pandas append to a concat and corrected string format of None

### DIFF
--- a/ncet/fill_scaling_table.py
+++ b/ncet/fill_scaling_table.py
@@ -55,6 +55,7 @@ def fill_scaling_table(path, fname, base, scalars_dict, scaling_table=None):
         sheet_name="21-Structures&Improvements",
         skiprows=[0],
         index_col="Account",
+        keep_default_na=False, na_values=['NaN'],
     )
     df22 = pd.read_excel(
         pjoin(path, fname),
@@ -274,10 +275,8 @@ def fill_scaling_table(path, fname, base, scalars_dict, scaling_table=None):
 
     # ------------------------------------------------------Account 22-26 ------------------------------------------------------#
     print("Evaluating account 22 - 26")
-    df_big = df22.append(df23)
-    df_big = df_big.append(df24)
-    df_big = df_big.append(df25)
-    df_big = df_big.append(df26)
+    df_big = pd.concat([df22, df23, df24, df25, df26])
+
 
     idx_PPS = df_big.index[df_big["Method"] == "Plant power scaling"]
     scaling_table.loc[idx_PPS, "Option"] = 2

--- a/ncet/get_indirect_costs.py
+++ b/ncet/get_indirect_costs.py
@@ -151,8 +151,10 @@ def get_indirect_costs(dfNewPlant, plant_characteristics, learning_rate, scalars
     np_indirect_cost["Account Description"] = "Indirect Costs"
     np_indirect_cost["Subcategories"] = 1
 
-    dfNewPlant = dfNewPlant.append(pd.Series(np_indirect_cost, name="A.9"))
-
+    dfNewPlant = pd.concat(
+        [dfNewPlant, pd.Series(np_indirect_cost, name="A.9").to_frame().T], 
+    )
+    
     # #----------------- Divide costs among correct overrun accounts ----------------
     # for col in ['Site Labor Hours', 'Site Labor Cost', 'Site Material Cost', 'Factory Equipment Cost']:
     # 	# pdb.set_trace()


### PR DESCRIPTION
Code fails to run on Python v3.9.16 with default dependencies installed from setup.py.

Corrected the following:
- converted a Pandas' append to a concat -- append has long since been deprecated
- code incorrectly converts a 'None' string to a NaN when reading input files. This is likely due to an outdated version of Pandas -- setup.py doesn't specify so the latest compatible version with Python v3.9.16 is adopted. Hence to correct, added the flags

   `keep_default_na=False, na_values=['NaN']` 

    when reading Excel files for "21-Structures&Improvements". These errors may also exist for other input tabs in the spreadsheet but the control flow from the standard inputs doesn't traverse and hence have not been checked.     